### PR TITLE
Fix if statement

### DIFF
--- a/src/extractor/webpack/bundle-info.ts
+++ b/src/extractor/webpack/bundle-info.ts
@@ -35,7 +35,7 @@ export const getWebpackBundleInfo = (callAST: CallExpression, options: Options):
     }
 
     // try to get entry id
-    if (typeof options.entryPoint !== "string" || typeof options.entryPoint !== "number") {
+    if (typeof options.entryPoint !== "string" && typeof options.entryPoint !== "number") {
         options.entryPoint = undefined
         try {
             // unminified file


### PR DESCRIPTION
The current if statement will **always** return true, causing the script to attempt to lookup the entrypoint, even if one has already been specified. This change fixes that by switching the operator.